### PR TITLE
upgrade fp-ts and io-ts, make io-ts a peerDependency instead and use …

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "io-ts-reporters",
   "main": "./target/src/index.js",
   "typings": "./target/src/index.d.ts",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "scripts": {
     "lint": "tslint --project tsconfig.json",
     "compile": "rm -rf ./target/* && tsc",
@@ -13,10 +13,13 @@
     "target/src"
   ],
   "dependencies": {
-    "fp-ts": "^0.6.2",
-    "io-ts": "^0.8.2"
+    "fp-ts": "^0.6.8"
+  },
+  "peerDependencies": {
+    "io-ts": "^0.9.7"
   },
   "devDependencies": {
+    "io-ts": "^0.9.7",
     "tslint": "^5.8.0",
     "typescript": "^2.6.1"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import * as array from 'fp-ts/lib/Array';
-import * as t from 'io-ts';
+import { mixed, Validation, ValidationError } from 'io-ts';
 
 // These are only needed for emitting TypeScript declarations
 /* tslint:disable no-unused-variable */
@@ -7,9 +7,9 @@ import { Left, Right } from 'fp-ts/lib/Either';
 import { None, Some } from 'fp-ts/lib/Option';
 /* tslint:enable no-unused-variable */
 
-const jsToString = (value: {}) => (value === undefined ? 'undefined' : JSON.stringify(value));
+const jsToString = (value: mixed) => (value === undefined ? 'undefined' : JSON.stringify(value));
 
-export const formatValidationError = (error: t.ValidationError) => {
+export const formatValidationError = (error: ValidationError) => {
     const path = error.context
         .map(c => c.key)
         // The context entry with an empty key is the original type ("default
@@ -32,6 +32,6 @@ export const formatValidationError = (error: t.ValidationError) => {
     });
 };
 
-export const reporter = (validation: t.Validation<{}>) => (
+export const reporter = (validation: Validation<mixed>) => (
     validation.fold(errors => array.catOptions(errors.map(formatValidationError)), () => [])
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -87,9 +87,9 @@ esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
-fp-ts@^0.6.0, fp-ts@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-0.6.2.tgz#2a0ca882af217c3e8f1bc69f6abda3a017233a72"
+fp-ts@^0.6.4, fp-ts@^0.6.8:
+  version "0.6.8"
+  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-0.6.8.tgz#3b4ac3251f3565b2aefceffd787eb06c30c04b52"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -127,11 +127,11 @@ inherits@2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
-io-ts@^0.8.2:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-0.8.2.tgz#cf87ca011f384c662d7ef1bb9657c069a22de7d4"
+io-ts@^0.9.7:
+  version "0.9.7"
+  resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-0.9.7.tgz#60c2e0c701583e1420ffa727c09e0e2f7cf85154"
   dependencies:
-    fp-ts "^0.6.0"
+    fp-ts "^0.6.4"
 
 js-tokens@^3.0.0:
   version "3.0.2"


### PR DESCRIPTION
…mixed instead of empty object type

this is to mainly fix a type incompatibility issue with io-ts when using io-ts 0.9.x or higher.