### PR TITLE
Unify union types in the same error

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,10 @@
+{
+  "printWidth": 80,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "none",
+  "bracketSpacing": true,
+  "arrowParens": "avoid"
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,49 +1,128 @@
-import * as array from 'fp-ts/lib/Array';
-import {fold} from 'fp-ts/lib/Either';
-import {map} from 'fp-ts/lib/Option';
-import {pipe} from 'fp-ts/lib/pipeable';
+import * as A from 'fp-ts/lib/Array';
+import * as E from 'fp-ts/lib/Either';
+import * as NEA from 'fp-ts/lib/NonEmptyArray';
+import * as O from 'fp-ts/lib/Option';
+import * as R from 'fp-ts/lib/Record';
+import { pipe } from 'fp-ts/lib/pipeable';
 import * as t from 'io-ts';
+
+import { takeUntil } from './utils';
+
+const isUnionType = ({ type }: t.ContextEntry) => type instanceof t.UnionType;
 
 const jsToString = (value: t.mixed) =>
   value === undefined ? 'undefined' : JSON.stringify(value);
 
-export const formatValidationError = (error: t.ValidationError) => {
-  const path = error.context
-    .map((c) => c.key)
-    // The context entry with an empty key is the original type ("default
-    // context"), not an type error.
-    .filter((key) => key.length > 0)
+const keyPath = (ctx: t.Context) =>
+  // The context entry with an empty key is the original
+  // type ("default context"), not a type error.
+  ctx
+    .map(c => c.key)
+    .filter(Boolean)
     .join('.');
 
-  // The actual error is last in context
-  const maybeErrorContext = array.last(
-    // https://github.com/gcanti/fp-ts/pull/544/files
-    error.context as t.ContextEntry[]
+// The actual error is last in context
+const getErrorFromCtx = (validation: t.ValidationError) =>
+  // https://github.com/gcanti/fp-ts/pull/544/files
+  A.last(validation.context as t.ContextEntry[]);
+
+const getValidationContext = (validation: t.ValidationError) =>
+  // https://github.com/gcanti/fp-ts/pull/544/files
+  validation.context as t.ContextEntry[];
+
+const errorMessageSimple = (
+  expectedType: string,
+  path: string,
+  error: t.ValidationError
+) =>
+  // https://github.com/elm-lang/core/blob/18c9e84e975ed22649888bfad15d1efdb0128ab2/src/Native/Json.js#L199
+  [
+    `Expecting ${expectedType}`,
+    path === '' ? '' : `at ${path}`,
+    `but instead got: ${jsToString(error.value)}`,
+    error.message ? `(${error.message})` : ''
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+// TODO: support error.message as errorMessageSimple does
+const errorMessageUnion = (
+  expectedTypes: string[],
+  path: string,
+  value: unknown
+) =>
+  // https://github.com/elm-lang/core/blob/18c9e84e975ed22649888bfad15d1efdb0128ab2/src/Native/Json.js#L199
+  [
+    'Expecting one of:\n',
+    expectedTypes.map(type => `    ${type}`).join('\n'),
+    path === '' ? '\n' : `\nat ${path} `,
+    `but instead got: ${jsToString(value)}`
+  ]
+    .filter(Boolean)
+    .join('');
+
+// Find the union type in the list of ContextEntry
+// The next ContextEntry should be the type of this branch of the union
+const findExpectedType = (ctx: t.ContextEntry[]) =>
+  pipe(
+    ctx,
+    A.findIndex(isUnionType),
+    O.chain(n => A.lookup(n + 1, ctx))
   );
 
-  return pipe(
-    maybeErrorContext,
-    map((errorContext) => {
-      const expectedType = errorContext.type.name;
-      // https://github.com/elm-lang/core/blob/18c9e84e975ed22649888bfad15d1efdb0128ab2/src/Native/Json.js#L199
-      return [
-        `Expecting ${expectedType}`,
-        path ? `at ${path}` : '',
-        'but instead got:',
-        jsToString(error.value),
-        error.message ? `(${error.message})` : ''
-      ]
-        .filter(Boolean)
-        .join(' ');
-    })
+const formatValidationErrorOfUnion = (
+  path: string,
+  errors: NEA.NonEmptyArray<t.ValidationError>
+) => {
+  const expectedTypes = pipe(
+    errors,
+    A.map(getValidationContext),
+    A.map(findExpectedType),
+    A.compact
   );
+
+  const value = pipe(
+    expectedTypes,
+    A.head,
+    O.map(v => v.actual),
+    O.getOrElse((): unknown => undefined)
+  );
+
+  const expected = expectedTypes.map(({ type }) => type.name);
+
+  return expected.length > 0
+    ? O.some(errorMessageUnion(expected, path, value))
+    : O.none;
 };
+
+const formatValidationError = (path: string, error: t.ValidationError) =>
+  pipe(
+    error,
+    getErrorFromCtx,
+    O.map(errorContext =>
+      errorMessageSimple(errorContext.type.name, path, error)
+    )
+  );
+
+const format = (path: string, errors: NEA.NonEmptyArray<t.ValidationError>) =>
+  NEA.tail(errors).length > 0
+    ? formatValidationErrorOfUnion(path, errors)
+    : formatValidationError(path, NEA.head(errors));
+
+const groupByKey = NEA.groupBy((error: t.ValidationError) =>
+  pipe(error.context, takeUntil(isUnionType), keyPath)
+);
 
 export const reporter = <T>(validation: t.Validation<T>) =>
   pipe(
     validation,
-    fold(
-      (errors) => array.compact(errors.map(formatValidationError)),
+    E.mapLeft(groupByKey),
+    E.mapLeft(R.mapWithIndex(format)),
+    E.mapLeft(R.compact),
+    E.mapLeft(R.toArray),
+    E.mapLeft(A.map(([_key, error]) => error)),
+    E.fold(
+      errors => errors,
       () => []
     )
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,6 @@ const errorMessageSimple = (
     .filter(Boolean)
     .join(' ');
 
-// TODO: support error.message as errorMessageSimple does
 const errorMessageUnion = (
   expectedTypes: string[],
   path: string,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,16 @@
+import { Predicate } from 'fp-ts/lib/function';
+
+export const takeUntil = <A = unknown>(predicate: Predicate<A>) => (
+  as: ReadonlyArray<A>
+): ReadonlyArray<A> => {
+  const init = [];
+
+  for (let i = 0; i < as.length; i++) {
+    init[i] = as[i];
+    if (predicate(as[i])) {
+      return init;
+    }
+  }
+
+  return init;
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,10 +1,12 @@
 import { Predicate } from 'fp-ts/lib/function';
 
+/* eslint-disable @typescript-eslint/array-type */
 export const takeUntil = <A = unknown>(predicate: Predicate<A>) => (
   as: ReadonlyArray<A>
 ): ReadonlyArray<A> => {
   const init = [];
 
+  // eslint-disable-next-line unicorn/no-for-loop
   for (let i = 0; i < as.length; i++) {
     init[i] = as[i];
     if (predicate(as[i])) {
@@ -14,3 +16,4 @@ export const takeUntil = <A = unknown>(predicate: Predicate<A>) => (
 
   return init;
 };
+/* eslint-enable @typescript-eslint/array-type */

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,24 +1,24 @@
 import test from 'ava';
 import * as iots from 'io-ts';
-import {withMessage} from 'io-ts-types/lib/withMessage';
+import { withMessage } from 'io-ts-types/lib/withMessage';
 
-import {reporter} from '../src';
+import { reporter } from '../src';
 
-test('reports an empty array when the result doesn’t contain errors', (t) => {
+test('reports an empty array when the result doesn’t contain errors', t => {
   const PrimitiveType = iots.string;
-  const result = PrimitiveType.decode('');
+  const result = PrimitiveType.decode('foo');
 
   t.deepEqual(reporter(result), []);
 });
 
-test('formats a top-level primitve type correctly', (t) => {
+test('formats a top-level primitve type correctly', t => {
   const PrimitiveType = iots.string;
   const result = PrimitiveType.decode(42);
 
   t.deepEqual(reporter(result), ['Expecting string but instead got: 42']);
 });
 
-test('formats array items', (t) => {
+test('formats array items', t => {
   const NumberGroups = iots.array(iots.array(iots.number));
   const result = NumberGroups.decode({});
 
@@ -27,7 +27,7 @@ test('formats array items', (t) => {
   ]);
 });
 
-test('formats nested array item mismatches correctly', (t) => {
+test('formats nested array item mismatches correctly', t => {
   const NumberGroups = iots.array(iots.array(iots.number));
   const result = NumberGroups.decode([[{}]]);
 
@@ -36,33 +36,7 @@ test('formats nested array item mismatches correctly', (t) => {
   ]);
 });
 
-test('formats a complex type correctly', (t) => {
-  const Gender = iots.union([iots.literal('Male'), iots.literal('Female')]);
-  const Person = iots.interface({
-    name: iots.string,
-    age: iots.number,
-    gender: Gender,
-    children: iots.array(
-      iots.interface({
-        gender: Gender
-      })
-    )
-  });
-  const result = Person.decode({
-    name: 'Giulio',
-    children: [{gender: 'Whatever'}]
-  });
-
-  t.deepEqual(reporter(result), [
-    'Expecting number at age but instead got: undefined',
-    'Expecting "Male" at gender.0 but instead got: undefined',
-    'Expecting "Female" at gender.1 but instead got: undefined',
-    'Expecting "Male" at children.0.gender.0 but instead got: "Whatever"',
-    'Expecting "Female" at children.0.gender.1 but instead got: "Whatever"'
-  ]);
-});
-
-test('formats branded types correctly', (t) => {
+test('formats branded types correctly', t => {
   interface PositiveBrand {
     readonly Positive: unique symbol;
   }
@@ -79,7 +53,7 @@ test('formats branded types correctly', (t) => {
 
   const PatronizingPositive = withMessage(
     Positive,
-    (_i) => `Don't be so negative!`
+    _i => `Don't be so negative!`
   );
 
   t.deepEqual(reporter(PatronizingPositive.decode(-1)), [

--- a/tests/unions.test.ts
+++ b/tests/unions.test.ts
@@ -1,0 +1,146 @@
+import test from 'ava';
+import * as iots from 'io-ts';
+
+import { reporter } from '../src';
+
+test('formats keyof unions as "regular" types', t => {
+  const WithKeyOf = iots.interface({
+    oneOf: iots.keyof({ a: null, b: null, c: null })
+  });
+
+  t.deepEqual(reporter(WithKeyOf.decode({ oneOf: '' })), [
+    'Expecting "a" | "b" | "c" at oneOf but instead got: ""'
+  ]);
+});
+
+test('union of string literals (no key)', t => {
+  t.deepEqual(reporter(Gender.decode('male')), [
+    [
+      'Expecting one of:',
+      '    "Male"',
+      '    "Female"',
+      '    "Other"',
+      'but instead got: "male"'
+    ].join('\n')
+  ]);
+});
+
+test('union of interfaces', t => {
+  const UnionOfInterfaces = iots.union([
+    iots.interface({ key: iots.string }),
+    iots.interface({ code: iots.number })
+  ]);
+  const WithUnion = iots.interface({ data: UnionOfInterfaces });
+
+  t.deepEqual(reporter(WithUnion.decode({})), [
+    [
+      'Expecting one of:',
+      '    { key: string }',
+      '    { code: number }',
+      'at data but instead got: undefined'
+    ].join('\n')
+  ]);
+
+  t.deepEqual(reporter(WithUnion.decode({ data: '' })), [
+    [
+      'Expecting one of:',
+      '    { key: string }',
+      '    { code: number }',
+      'at data but instead got: ""'
+    ].join('\n')
+  ]);
+
+  t.deepEqual(reporter(WithUnion.decode({ data: {} })), [
+    [
+      'Expecting one of:',
+      '    { key: string }',
+      '    { code: number }',
+      'at data but instead got: {}'
+    ].join('\n')
+  ]);
+
+  t.deepEqual(reporter(WithUnion.decode({ data: { code: '123' } })), [
+    [
+      'Expecting one of:',
+      '    { key: string }',
+      '    { code: number }',
+      'at data but instead got: {"code":"123"}'
+    ].join('\n')
+  ]);
+});
+
+const Gender = iots.union([
+  iots.literal('Male'),
+  iots.literal('Female'),
+  iots.literal('Other')
+]);
+
+test('string union when provided undefined', t => {
+  const Person = iots.interface({ name: iots.string, gender: Gender });
+
+  t.deepEqual(reporter(Person.decode({ name: 'Jane' })), [
+    [
+      'Expecting one of:',
+      '    "Male"',
+      '    "Female"',
+      '    "Other"',
+      'at gender but instead got: undefined'
+    ].join('\n')
+  ]);
+});
+
+test('string union when provided another string', t => {
+  const Person = iots.interface({ name: iots.string, gender: Gender });
+
+  t.deepEqual(reporter(Person.decode({ name: 'Jane', gender: 'female' })), [
+    [
+      'Expecting one of:',
+      '    "Male"',
+      '    "Female"',
+      '    "Other"',
+      'at gender but instead got: "female"'
+    ].join('\n')
+  ]);
+
+  t.deepEqual(reporter(Person.decode({ name: 'Jane' })), [
+    [
+      'Expecting one of:',
+      '    "Male"',
+      '    "Female"',
+      '    "Other"',
+      'at gender but instead got: undefined'
+    ].join('\n')
+  ]);
+});
+
+test('string union deeply nested', t => {
+  const Person = iots.interface({
+    name: iots.string,
+    children: iots.array(iots.interface({ gender: Gender }))
+  });
+
+  t.deepEqual(
+    reporter(
+      Person.decode({
+        name: 'Jane',
+        children: [{}, { gender: 'Whatever' }]
+      })
+    ),
+    [
+      [
+        'Expecting one of:',
+        '    "Male"',
+        '    "Female"',
+        '    "Other"',
+        'at children.0.gender but instead got: undefined'
+      ].join('\n'),
+      [
+        'Expecting one of:',
+        '    "Male"',
+        '    "Female"',
+        '    "Other"',
+        'at children.1.gender but instead got: "Whatever"'
+      ].join('\n')
+    ]
+  );
+});


### PR DESCRIPTION
Improves on #5

I started to work on the reporting of union types errors. It's not yet finished, but I'd like some feedback on the code (I think my editor applied automatic formatting btw 🤦‍♂) and also on how the errors look.

Here are some examples one the errors, and what's still missing.

**t.keyof**

[`io-ts` suggests to use `t.keyof` for union types of only string literals](https://github.com/gcanti/io-ts#union-of-string-literals).

```ts
const OneOf = t.interface({
    oneOf: t.keyof({ a: null, b: null, c: null }),
});

report(OneOf.decode({ oneOf: '' }));
```

That still reports as before:

```
Expecting "a" | "b" | "c" at oneOf but instead got: "A".
```

**Literals unions** (using `t.union`):

```ts
const StringUnion = t.interface({
    stringUnion: t.union([t.literal('a'), t.literal('b'), t.literal('c')]),
});
report(StringUnion.decode({ stringUnion: 'A' }));
```

Reports with the new format (instead of showing 3 different errors):

```
Expecting one of:
    "a"
    "b"
    "c"
at stringUnion but instead got: "A".
```

**Things to improve**:

There are some things that should still be improved. For unions of other types, I need to do some improvements on the usage of the context to get proper errors.

```ts
const Unions = t.interface({
    interfaceUnion: t.union([
        t.interface({ key: t.string }),
        t.interface({ code: t.number }),
    ]),
});
```

For such union, the following input would give the error one expects:

```ts
report(Unions.decode({ interfaceUnion: 'name' }));
```

```
Expecting one of:
    { key: string }
    { code: number }
at interfaceUnion but instead got: "name".
```

But for the case when there's more context of the value:

```ts
report(Unions.decode({ interfaceUnion: {} }));
```

The error is wrong 😕 

```
Expecting one of:
    string
    number
at interfaceUnion but instead got: undefined.
```