### PR TITLE
docs(DeadLink): Fix 'See tests' link by setting suffix to test.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ yarn add io-ts-reporters
 
 ## Example
 
-See [the tests](./tests/index.ts).
+See [the tests](./tests/index.test.ts).
 
 ## Testing
 


### PR DESCRIPTION
This fixes the broken link to the index test file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gillchristian/io-ts-reporters/31)
<!-- Reviewable:end -->
