### PR TITLE
Truncate long types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,10 @@ const getValidationContext = (validation: t.ValidationError) =>
   // https://github.com/gcanti/fp-ts/pull/544/files
   validation.context as t.ContextEntry[];
 
+export const TYPE_MAX_LEN = 160; // Two lines of 80-col text
+const truncateType = (type: string): string =>
+  type.length > TYPE_MAX_LEN ? `${type.slice(0, TYPE_MAX_LEN - 3)}...` : type;
+
 const errorMessageSimple = (
   expectedType: string,
   path: string,
@@ -37,7 +41,7 @@ const errorMessageSimple = (
 ) =>
   // https://github.com/elm-lang/core/blob/18c9e84e975ed22649888bfad15d1efdb0128ab2/src/Native/Json.js#L199
   [
-    `Expecting ${expectedType}`,
+    `Expecting ${truncateType(expectedType)}`,
     path === '' ? '' : `at ${path}`,
     `but instead got: ${jsToString(error.value)}`,
     error.message ? `(${error.message})` : ''
@@ -53,7 +57,7 @@ const errorMessageUnion = (
   // https://github.com/elm-lang/core/blob/18c9e84e975ed22649888bfad15d1efdb0128ab2/src/Native/Json.js#L199
   [
     'Expecting one of:\n',
-    expectedTypes.map(type => `    ${type}`).join('\n'),
+    expectedTypes.map(type => `    ${truncateType(type)}`).join('\n'),
     path === '' ? '\n' : `\nat ${path} `,
     `but instead got: ${jsToString(value)}`
   ]

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,10 @@ const getValidationContext = (validation: t.ValidationError) =>
   // https://github.com/gcanti/fp-ts/pull/544/files
   validation.context as t.ContextEntry[];
 
+/**
+ * @category internals
+ * @since 1.2.1
+ */
 export const TYPE_MAX_LEN = 160; // Two lines of 80-col text
 const truncateType = (type: string): string =>
   type.length > TYPE_MAX_LEN ? `${type.slice(0, TYPE_MAX_LEN - 3)}...` : type;

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -2,7 +2,7 @@ import test from 'ava';
 import * as iots from 'io-ts';
 import { withMessage } from 'io-ts-types/lib/withMessage';
 
-import { reporter } from '../src';
+import { reporter, TYPE_MAX_LEN } from '../src';
 
 test('reports an empty array when the result doesn’t contain errors', t => {
   const PrimitiveType = iots.string;
@@ -59,4 +59,20 @@ test('formats branded types correctly', t => {
   t.deepEqual(reporter(PatronizingPositive.decode(-1)), [
     "Expecting Positive but instead got: -1 (Don't be so negative!)"
   ]);
+});
+
+test('truncates really long types', t => {
+  const longType = iots.type({
+    '1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890':
+      iots.number
+  });
+  const messages = reporter(longType.decode(null));
+  t.is(messages.length, 1);
+  t.regex(
+    messages[0],
+    new RegExp(
+      `^Expecting .{${TYPE_MAX_LEN - 3}}\\.{3} but instead got: null$`
+    ),
+    'Should be truncated'
+  );
 });


### PR DESCRIPTION
Super long types in my app are pretty hard to read, this cuts them to 160 chars max.

Closes #2 