### PR TITLE
fix: Expose format errors functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,36 @@ yarn add io-ts-reporters
 
 ## Example
 
-See [the tests](./tests/index.test.ts).
+```ts
+import * as t from 'io-ts';
+import reporter, { formatValidationErrors } from 'io-ts-reporters';
+import * as E from 'fp-ts/lib/Either';
+
+const User = t.interface({ name: t.string });
+
+// When decoding fails, the errors are reported
+reporter.report(User.decode({ nam: 'Jane' }));
+//=> ['Expecting string at name but instead got: undefined']
+
+// Nothing gets reported on success
+reporter.report(User.decode({ name: 'Jane' }));
+//=> []
+```
+
+If you want to report the errors on the `Left` only use `formatValidationErrors` instead.
+
+```ts
+import * as t from 'io-ts';
+import { formatValidationErrors } from 'io-ts-reporters';
+import * as E from 'fp-ts/lib/Either';
+import { pipe } from 'fp-ts/lib/pipeable';
+
+const User = t.interface({ name: t.string });
+
+pipe({ nam: 'Jane' }, User.decode, E.mapLeft(formatValidationErrors));
+```
+
+For more examples see [the tests](./tests/index.test.ts).
 
 ## Testing
 
@@ -31,3 +60,7 @@ yarn run test
 ```
 
 [io-ts]: https://github.com/gcanti/io-ts#error-reporters
+
+## Credits
+
+This library was created by [OliverJAsh](https://github.com/OliverJAsh).

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,7 +113,7 @@ const format = (path: string, errors: NEA.NonEmptyArray<t.ValidationError>) =>
     ? formatValidationErrorOfUnion(path, errors)
     : formatValidationCommonError(path, NEA.head(errors));
 
-// this is kept for backwards compatibility
+// Kept for backwards compatibility.
 export const formatValidationError = (error: t.ValidationError) =>
   formatValidationCommonError(keyPath(error.context), error);
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -2,27 +2,29 @@ import test from 'ava';
 import * as iots from 'io-ts';
 import { withMessage } from 'io-ts-types/lib/withMessage';
 
-import { reporter } from '../src';
+import reporter from '../src';
 
 test('reports an empty array when the result doesn’t contain errors', t => {
   const PrimitiveType = iots.string;
   const result = PrimitiveType.decode('foo');
 
-  t.deepEqual(reporter(result), []);
+  t.deepEqual(reporter.report(result), []);
 });
 
 test('formats a top-level primitve type correctly', t => {
   const PrimitiveType = iots.string;
   const result = PrimitiveType.decode(42);
 
-  t.deepEqual(reporter(result), ['Expecting string but instead got: 42']);
+  t.deepEqual(reporter.report(result), [
+    'Expecting string but instead got: 42'
+  ]);
 });
 
 test('formats array items', t => {
   const NumberGroups = iots.array(iots.array(iots.number));
   const result = NumberGroups.decode({});
 
-  t.deepEqual(reporter(result), [
+  t.deepEqual(reporter.report(result), [
     'Expecting Array<Array<number>> but instead got: {}'
   ]);
 });
@@ -31,7 +33,7 @@ test('formats nested array item mismatches correctly', t => {
   const NumberGroups = iots.array(iots.array(iots.number));
   const result = NumberGroups.decode([[{}]]);
 
-  t.deepEqual(reporter(result), [
+  t.deepEqual(reporter.report(result), [
     'Expecting number at 0.0 but instead got: {}'
   ]);
 });
@@ -47,7 +49,7 @@ test('formats branded types correctly', t => {
     'Positive'
   );
 
-  t.deepEqual(reporter(Positive.decode(-1)), [
+  t.deepEqual(reporter.report(Positive.decode(-1)), [
     'Expecting Positive but instead got: -1'
   ]);
 
@@ -56,7 +58,7 @@ test('formats branded types correctly', t => {
     _i => `Don't be so negative!`
   );
 
-  t.deepEqual(reporter(PatronizingPositive.decode(-1)), [
+  t.deepEqual(reporter.report(PatronizingPositive.decode(-1)), [
     "Expecting Positive but instead got: -1 (Don't be so negative!)"
   ]);
 });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -2,20 +2,20 @@ import test from 'ava';
 import * as iots from 'io-ts';
 import { withMessage } from 'io-ts-types/lib/withMessage';
 
-import reporter from '../src';
+import Reporter from '../src';
 
 test('reports an empty array when the result doesn’t contain errors', t => {
   const PrimitiveType = iots.string;
   const result = PrimitiveType.decode('foo');
 
-  t.deepEqual(reporter.report(result), []);
+  t.deepEqual(Reporter.report(result), []);
 });
 
 test('formats a top-level primitve type correctly', t => {
   const PrimitiveType = iots.string;
   const result = PrimitiveType.decode(42);
 
-  t.deepEqual(reporter.report(result), [
+  t.deepEqual(Reporter.report(result), [
     'Expecting string but instead got: 42'
   ]);
 });
@@ -24,7 +24,7 @@ test('formats array items', t => {
   const NumberGroups = iots.array(iots.array(iots.number));
   const result = NumberGroups.decode({});
 
-  t.deepEqual(reporter.report(result), [
+  t.deepEqual(Reporter.report(result), [
     'Expecting Array<Array<number>> but instead got: {}'
   ]);
 });
@@ -33,7 +33,7 @@ test('formats nested array item mismatches correctly', t => {
   const NumberGroups = iots.array(iots.array(iots.number));
   const result = NumberGroups.decode([[{}]]);
 
-  t.deepEqual(reporter.report(result), [
+  t.deepEqual(Reporter.report(result), [
     'Expecting number at 0.0 but instead got: {}'
   ]);
 });
@@ -49,7 +49,7 @@ test('formats branded types correctly', t => {
     'Positive'
   );
 
-  t.deepEqual(reporter.report(Positive.decode(-1)), [
+  t.deepEqual(Reporter.report(Positive.decode(-1)), [
     'Expecting Positive but instead got: -1'
   ]);
 
@@ -58,7 +58,7 @@ test('formats branded types correctly', t => {
     _i => `Don't be so negative!`
   );
 
-  t.deepEqual(reporter.report(PatronizingPositive.decode(-1)), [
+  t.deepEqual(Reporter.report(PatronizingPositive.decode(-1)), [
     "Expecting Positive but instead got: -1 (Don't be so negative!)"
   ]);
 });

--- a/tests/unions.test.ts
+++ b/tests/unions.test.ts
@@ -1,20 +1,20 @@
 import test from 'ava';
 import * as iots from 'io-ts';
 
-import reporter from '../src';
+import Reporter from '../src';
 
 test('formats keyof unions as "regular" types', t => {
   const WithKeyOf = iots.interface({
     oneOf: iots.keyof({ a: null, b: null, c: null })
   });
 
-  t.deepEqual(reporter.report(WithKeyOf.decode({ oneOf: '' })), [
+  t.deepEqual(Reporter.report(WithKeyOf.decode({ oneOf: '' })), [
     'Expecting "a" | "b" | "c" at oneOf but instead got: ""'
   ]);
 });
 
 test('union of string literals (no key)', t => {
-  t.deepEqual(reporter.report(Gender.decode('male')), [
+  t.deepEqual(Reporter.report(Gender.decode('male')), [
     [
       'Expecting one of:',
       '    "Male"',
@@ -32,7 +32,7 @@ test('union of interfaces', t => {
   ]);
   const WithUnion = iots.interface({ data: UnionOfInterfaces });
 
-  t.deepEqual(reporter.report(WithUnion.decode({})), [
+  t.deepEqual(Reporter.report(WithUnion.decode({})), [
     [
       'Expecting one of:',
       '    { key: string }',
@@ -41,7 +41,7 @@ test('union of interfaces', t => {
     ].join('\n')
   ]);
 
-  t.deepEqual(reporter.report(WithUnion.decode({ data: '' })), [
+  t.deepEqual(Reporter.report(WithUnion.decode({ data: '' })), [
     [
       'Expecting one of:',
       '    { key: string }',
@@ -50,7 +50,7 @@ test('union of interfaces', t => {
     ].join('\n')
   ]);
 
-  t.deepEqual(reporter.report(WithUnion.decode({ data: {} })), [
+  t.deepEqual(Reporter.report(WithUnion.decode({ data: {} })), [
     [
       'Expecting one of:',
       '    { key: string }',
@@ -59,7 +59,7 @@ test('union of interfaces', t => {
     ].join('\n')
   ]);
 
-  t.deepEqual(reporter.report(WithUnion.decode({ data: { code: '123' } })), [
+  t.deepEqual(Reporter.report(WithUnion.decode({ data: { code: '123' } })), [
     [
       'Expecting one of:',
       '    { key: string }',
@@ -78,7 +78,7 @@ const Gender = iots.union([
 test('string union when provided undefined', t => {
   const Person = iots.interface({ name: iots.string, gender: Gender });
 
-  t.deepEqual(reporter.report(Person.decode({ name: 'Jane' })), [
+  t.deepEqual(Reporter.report(Person.decode({ name: 'Jane' })), [
     [
       'Expecting one of:',
       '    "Male"',
@@ -93,7 +93,7 @@ test('string union when provided another string', t => {
   const Person = iots.interface({ name: iots.string, gender: Gender });
 
   t.deepEqual(
-    reporter.report(Person.decode({ name: 'Jane', gender: 'female' })),
+    Reporter.report(Person.decode({ name: 'Jane', gender: 'female' })),
     [
       [
         'Expecting one of:',
@@ -105,7 +105,7 @@ test('string union when provided another string', t => {
     ]
   );
 
-  t.deepEqual(reporter.report(Person.decode({ name: 'Jane' })), [
+  t.deepEqual(Reporter.report(Person.decode({ name: 'Jane' })), [
     [
       'Expecting one of:',
       '    "Male"',
@@ -123,7 +123,7 @@ test('string union deeply nested', t => {
   });
 
   t.deepEqual(
-    reporter.report(
+    Reporter.report(
       Person.decode({
         name: 'Jane',
         children: [{}, { gender: 'Whatever' }]

--- a/tests/unions.test.ts
+++ b/tests/unions.test.ts
@@ -1,20 +1,20 @@
 import test from 'ava';
 import * as iots from 'io-ts';
 
-import { reporter } from '../src';
+import reporter from '../src';
 
 test('formats keyof unions as "regular" types', t => {
   const WithKeyOf = iots.interface({
     oneOf: iots.keyof({ a: null, b: null, c: null })
   });
 
-  t.deepEqual(reporter(WithKeyOf.decode({ oneOf: '' })), [
+  t.deepEqual(reporter.report(WithKeyOf.decode({ oneOf: '' })), [
     'Expecting "a" | "b" | "c" at oneOf but instead got: ""'
   ]);
 });
 
 test('union of string literals (no key)', t => {
-  t.deepEqual(reporter(Gender.decode('male')), [
+  t.deepEqual(reporter.report(Gender.decode('male')), [
     [
       'Expecting one of:',
       '    "Male"',
@@ -32,7 +32,7 @@ test('union of interfaces', t => {
   ]);
   const WithUnion = iots.interface({ data: UnionOfInterfaces });
 
-  t.deepEqual(reporter(WithUnion.decode({})), [
+  t.deepEqual(reporter.report(WithUnion.decode({})), [
     [
       'Expecting one of:',
       '    { key: string }',
@@ -41,7 +41,7 @@ test('union of interfaces', t => {
     ].join('\n')
   ]);
 
-  t.deepEqual(reporter(WithUnion.decode({ data: '' })), [
+  t.deepEqual(reporter.report(WithUnion.decode({ data: '' })), [
     [
       'Expecting one of:',
       '    { key: string }',
@@ -50,7 +50,7 @@ test('union of interfaces', t => {
     ].join('\n')
   ]);
 
-  t.deepEqual(reporter(WithUnion.decode({ data: {} })), [
+  t.deepEqual(reporter.report(WithUnion.decode({ data: {} })), [
     [
       'Expecting one of:',
       '    { key: string }',
@@ -59,7 +59,7 @@ test('union of interfaces', t => {
     ].join('\n')
   ]);
 
-  t.deepEqual(reporter(WithUnion.decode({ data: { code: '123' } })), [
+  t.deepEqual(reporter.report(WithUnion.decode({ data: { code: '123' } })), [
     [
       'Expecting one of:',
       '    { key: string }',
@@ -78,7 +78,7 @@ const Gender = iots.union([
 test('string union when provided undefined', t => {
   const Person = iots.interface({ name: iots.string, gender: Gender });
 
-  t.deepEqual(reporter(Person.decode({ name: 'Jane' })), [
+  t.deepEqual(reporter.report(Person.decode({ name: 'Jane' })), [
     [
       'Expecting one of:',
       '    "Male"',
@@ -92,17 +92,20 @@ test('string union when provided undefined', t => {
 test('string union when provided another string', t => {
   const Person = iots.interface({ name: iots.string, gender: Gender });
 
-  t.deepEqual(reporter(Person.decode({ name: 'Jane', gender: 'female' })), [
+  t.deepEqual(
+    reporter.report(Person.decode({ name: 'Jane', gender: 'female' })),
     [
-      'Expecting one of:',
-      '    "Male"',
-      '    "Female"',
-      '    "Other"',
-      'at gender but instead got: "female"'
-    ].join('\n')
-  ]);
+      [
+        'Expecting one of:',
+        '    "Male"',
+        '    "Female"',
+        '    "Other"',
+        'at gender but instead got: "female"'
+      ].join('\n')
+    ]
+  );
 
-  t.deepEqual(reporter(Person.decode({ name: 'Jane' })), [
+  t.deepEqual(reporter.report(Person.decode({ name: 'Jane' })), [
     [
       'Expecting one of:',
       '    "Male"',
@@ -120,7 +123,7 @@ test('string union deeply nested', t => {
   });
 
   t.deepEqual(
-    reporter(
+    reporter.report(
       Person.decode({
         name: 'Jane',
         children: [{}, { gender: 'Whatever' }]


### PR DESCRIPTION
This PR fixes the breaking change introduced in #17 (https://github.com/gillchristian/io-ts-reporters/pull/17#pullrequestreview-435624895).

Also exports a [Reporter](https://gcanti.github.io/io-ts/modules/Reporter.ts.html#reporter-interface) as default (see: https://gcanti.github.io/io-ts/modules/PathReporter.ts.html) and a short example in the README.md