### PR TITLE
refactor: 💡 use fp-ts 2.8 bare imports for bundle size

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "io-ts-reporters",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Formatting of io-ts validation errors",
   "main": "./target/src/index.js",
   "typings": "./target/src/index.d.ts",


### PR DESCRIPTION
It lets the user's bundler decide whether to use the `/lib/` or `/es6/` imports, allowing tree shaking to work.

However it requires `fp-ts@2.8.0` so that might be breaking for some end users.